### PR TITLE
Fix byte spacing in hex view

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,10 +62,10 @@ export function activate(context: vscode.ExtensionContext) {
                                                 border: 1px solid var(--vscode-input-border);
                                         }
 					table { border-collapse: collapse; margin-right: 10px; }
-					td { padding: 0 5px; vertical-align: top; }
+                                        td { padding: 0 2px; vertical-align: top; }
 					.address td { color: gray; user-select: text; }
 					.hex td { letter-spacing: 0.1em; user-select: text; }
-                                        .ascii td { padding-left: 10px; user-select: text; }
+                                        .ascii td { padding-left: 2px; user-select: text; }
                                         .byte { outline: none; min-width: 20px; text-align: center; }
                                         .view-container { display: flex; }
 				</style>


### PR DESCRIPTION
## Summary
- update CSS for hex/ascii tables to reduce spacing

## Testing
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_684edc297920832484e9e3a3dd3e1abd