### PR TITLE
Refactor extension and parser modules

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface FormatOptions {
+    html: string;
+    paths: Record<string, string>;
+}
+
+export function loadFormatOptions(workspaceFolder: string | undefined, output: { appendLine(msg: string): void }): FormatOptions {
+    let html = '';
+    const paths: Record<string, string> = {};
+
+    if (!workspaceFolder) {
+        return { html, paths };
+    }
+
+    const configPath = path.join(workspaceFolder, 'binpp.json');
+    if (!fs.existsSync(configPath)) {
+        return { html, paths };
+    }
+
+    try {
+        const configRaw = fs.readFileSync(configPath, 'utf8');
+        const config = JSON.parse(configRaw) as { formats?: string[] };
+        const dirs = config.formats ?? [];
+        const formatFiles: string[] = ['(None)'];
+        for (const d of dirs) {
+            const absDir = path.isAbsolute(d) ? d : path.join(workspaceFolder, d);
+            if (fs.existsSync(absDir) && fs.statSync(absDir).isDirectory()) {
+                for (const f of fs.readdirSync(absDir)) {
+                    if (f.endsWith('.h')) {
+                        formatFiles.push(f);
+                        paths[f] = path.join(absDir, f);
+                    }
+                }
+            }
+        }
+        html = formatFiles.map(f => `<option value="${f}">${f}</option>`).join('');
+    } catch (err: any) {
+        const msg = err?.message || String(err);
+        output.appendLine(`[config] ${msg}`);
+        if (err?.stack) {
+            output.appendLine(err.stack);
+        }
+    }
+
+    return { html, paths };
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,280 +1,84 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
 import * as fs from 'fs';
+import * as path from 'path';
 import { parseFormatFile, parseBinary, treeToHtml, FormatDef } from './parser';
+import { loadFormatOptions } from './config';
+import { getHexViewHtml } from './webview/html';
 
-export function activate(context: vscode.ExtensionContext) {
+export function activate(context: vscode.ExtensionContext): void {
+    const output = vscode.window.createOutputChannel('binpp');
+    output.appendLine('binpp extension activated');
 
-        const output = vscode.window.createOutputChannel('binpp');
-        output.appendLine('binpp extension activated');
+    const disposable = vscode.commands.registerCommand('binpp.open', () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            vscode.window.showInformationMessage('No active editor found.');
+            return;
+        }
+        const document = editor.document;
+        const fileName = path.basename(document.fileName);
 
-        const disposable = vscode.commands.registerCommand('binpp.open', () => {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        const { html: formatOptionsHtml, paths: formatPaths } = loadFormatOptions(workspaceFolder, output);
+        let currentFormat: FormatDef | undefined;
 
-                const editor = vscode.window.activeTextEditor;
-		if (!editor) {
-			vscode.window.showInformationMessage('No active editor found.');
-			return;
-		}
-		const document = editor.document;
+        const panel = vscode.window.createWebviewPanel(
+            'hexView',
+            `Preview ${fileName}`,
+            vscode.ViewColumn.One,
+            { enableScripts: true }
+        );
 
-               const fileName = path.basename(document.fileName);
+        const fileBytes = fs.readFileSync(document.uri.fsPath);
+        const base64Data = fileBytes.toString('base64');
 
-               // Load format definitions from binpp.json
-               const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-               let formatOptionsHtml = '';
-               const formatPaths: Record<string, string> = {};
-               let currentFormat: FormatDef | undefined;
-               if (workspaceFolder) {
-                       const configPath = path.join(workspaceFolder, 'binpp.json');
-                       if (fs.existsSync(configPath)) {
-                               try {
-                                       const configRaw = fs.readFileSync(configPath, 'utf8');
-                                       const config = JSON.parse(configRaw) as { formats?: string[] };
-                                       const dirs = config.formats ?? [];
-                                       const formatFiles: string[] = ["(None)"];
-                                       for (const d of dirs) {
-                                               const absDir = path.isAbsolute(d) ? d : path.join(workspaceFolder, d);
-                                               if (fs.existsSync(absDir) && fs.statSync(absDir).isDirectory()) {
-                                                       for (const f of fs.readdirSync(absDir)) {
-                                                               if (f.endsWith('.h')) {
-                                                                       formatFiles.push(f);
-                                                                       formatPaths[f] = path.join(absDir, f);
-                                                               }
-                                                       }
-                                               }
-                                       }
-                                       formatOptionsHtml = formatFiles.map(f => `<option value="${f}">${f}</option>`).join('');
-                               } catch (err: any) {
-                                       const msg = err?.message || String(err);
-                                       output.appendLine(`[config] ${msg}`);
-                                       if (err?.stack) {
-                                               output.appendLine(err.stack);
-                                       }
-                                       console.error('Failed to read binpp.json', err);
-                                       vscode.window.showErrorMessage('Failed to read binpp.json: ' + msg + '. See "binpp" output for details.');
-                               }
-                       }
-               }
+        const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+        statusBarItem.text = 'Offset: 0x00000000';
+        statusBarItem.show();
+        context.subscriptions.push(statusBarItem);
 
-               const panel = vscode.window.createWebviewPanel(
-			'hexView',
-			`Preview ${fileName}`,
-			vscode.ViewColumn.One,
-			{ enableScripts: true }
-		);
-
-
-               const initialBytesPerLine = 16;
-               const initialOffset = 0;
-
-               const fileBytes = fs.readFileSync(document.uri.fsPath);
-               const base64Data = fileBytes.toString('base64');
-
-               const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-               statusBarItem.text = 'Offset: 0x00000000';
-               statusBarItem.show();
-               context.subscriptions.push(statusBarItem);
-
-		const hexViewHtml = `
-			<html>
-			<head>
-                               <meta name="color-scheme" content="light dark" />
-
-                                <style>
-                                        body {
-                                                font-family: monospace;
-                                                display: flex;
-                                                flex-direction: column;
-                                                color: var(--vscode-editor-foreground);
-                                                background-color: var(--vscode-editor-background);
-                                        }
-                                        .toolbar {
-                                                margin-bottom: 10px;
-                                                position: sticky;
-                                                top: 0;
-                                                background-color: var(--vscode-editor-background);
-                                                color: var(--vscode-editor-foreground);
-                                                padding: 4px;
-                                                z-index: 1;
-                                        }
-                                        input, select {
-                                                background-color: var(--vscode-input-background);
-                                                color: var(--vscode-input-foreground);
-                                                border: 1px solid var(--vscode-input-border);
-                                        }
-					table { border-collapse: collapse; margin-right: 10px; }
-					td { padding: 0 5px; vertical-align: top; }
-					.address td { color: gray; user-select: text; }
-					.hex td { letter-spacing: 0.1em; user-select: text; }
-                                        .ascii td { padding-left: 10px; user-select: text; }
-                                        .byte { outline: none; min-width: 20px; text-align: center; }
-                                        .view-container { display: flex; }
-                                        .tree-table { border-collapse: collapse; width: 100%; }
-                                        .tree-table td, .tree-table th { border: 1px solid; padding: 2px 4px; }
-                                        .tree-table .name { white-space: pre; }
-                                        .tree-table .toggle { cursor: pointer; display: inline-block; width: 1em; }
-                                        .tree-table tr.hidden { display: none; }
-                               </style>
-			</head>
-			<body>
-                        <div class="toolbar">
-                                        <label for="offset">Offset: </label>
-                                        <input id="offset" type="number" value="0" style="width:100px;" />
-                                        <label for="bytesPerLine">Bytes per line: </label>
-                                        <select id="bytesPerLine">
-                                                <option value="1">1</option>
-                                                <option value="2">2</option>
-                                                <option value="4">4</option>
-                                                <option value="8">8</option>
-                                                <option value="16" selected>16</option>
-                                                <option value="32">32</option>
-                                                <option value="64">64</option>
-                                                <option value="128">128</option>
-                                        </select>
-                                        <label for="formatSelect">Format: </label>
-                                        <select id="formatSelect">
-                                                ${formatOptionsHtml}
-                                        </select>
-                                </div>
-                                <div class="view-container" id="viewContainer"></div>
-                                <script>
-                                        const vscode = acquireVsCodeApi();
-                                        const rawData = '${base64Data}';
-                                        const bytes = Uint8Array.from(atob(rawData), c => c.charCodeAt(0));
-                                        const select = document.getElementById('bytesPerLine');
-                                        const formatSelect = document.getElementById('formatSelect');
-                                        const offsetInput = document.getElementById('offset');
-                                        const viewContainer = document.getElementById('viewContainer');
-
-                                        let currentFocusIndex = -1;
-
-                                        function renderView(bytesPerLine, offset) {
-                                                const slice = bytes.slice(offset);
-                                                let addr = '';
-                                                let hex = '';
-                                                let ascii = '';
-                                                for (let i = 0; i < slice.length; i += bytesPerLine) {
-                                                        const row = slice.slice(i, i + bytesPerLine);
-                                                        const address = (offset + i).toString(16).padStart(8, '0');
-                                                        addr += '<tr><td>' + address + '</td></tr>';
-                                                        hex += '<tr>';
-                                                        ascii += '<tr>';
-                                                        for (let j = 0; j < row.length; j++) {
-                                                                const idx = offset + i + j;
-                                                                const b = row[j];
-                                                                hex += \`<td class="byte" data-index="\${idx}" contenteditable="true">\${b.toString(16).padStart(2, '0')}</td>\`;
-                                                                ascii += \`<td>\${(b >= 32 && b <= 126) ? String.fromCharCode(b) : '.'}</td>\`;
-                                                        }
-                                                        hex += '</tr>';
-                                                        ascii += '</tr>';
-                                                }
-                                                return '<table class="address">' + addr + '</table>' +
-                                                       '<table class="hex">' + hex + '</table>' +
-                                                       '<table class="ascii">' + ascii + '</table>';
-                                        }
-
-                                        let currentBytesPerLine = ${initialBytesPerLine};
-                                        let currentOffset = ${initialOffset};
-
-                                        function updateView(focusIndex = -1) {
-                                                currentBytesPerLine = parseInt(select.value, 10);
-                                                currentOffset = parseInt(offsetInput.value, 10) || 0;
-                                                viewContainer.style.display = 'flex';
-                                                viewContainer.innerHTML = renderView(currentBytesPerLine, currentOffset);
-                                                if (focusIndex >= 0) {
-                                                        const el = viewContainer.querySelector(\`td.byte[data-index="\${focusIndex}"]\`);
-                                                        if (el instanceof HTMLElement) {
-                                                                el.focus();
-                                                        }
-                                                }
-                                        }
-
-                                        select.addEventListener('change', updateView);
-                                        offsetInput.addEventListener('change', updateView);
-                                       formatSelect?.addEventListener('change', () => {
-                                               vscode.postMessage({ type: 'formatChange', value: formatSelect.value });
-                                       });
-
-
-                                        window.addEventListener('message', event => {
-                                                const msg = event.data;
-                                                if (msg.type === 'treeData') {
-                                                        if (msg.html) {
-                                                                viewContainer.style.display = 'block';
-                                                                viewContainer.innerHTML = msg.html;
-                                                        } else {
-                                                                updateView();
-                                                        }
-                                                }
-                                        });
-
-                                        viewContainer.addEventListener('focusin', e => {
-                                                const target = e.target;
-                                                if (target instanceof HTMLElement && target.classList.contains('byte')) {
-                                                        currentFocusIndex = parseInt(target.getAttribute('data-index') || '0', 10);
-                                                        vscode.postMessage({ type: 'cursorMove', index: currentFocusIndex });
-                                                }
-                                        });
-
-                                        viewContainer.addEventListener('input', e => {
-                                                const target = e.target;
-                                                if (target instanceof HTMLElement && target.classList.contains('byte')) {
-                                                        const idx = parseInt(target.getAttribute('data-index') || '0', 10);
-                                                        let text = (target.textContent || '').trim();
-                                                        if (/^[0-9a-fA-F]{1,2}$/.test(text)) {
-                                                                const value = parseInt(text, 16);
-                                                                bytes[idx] = value;
-                                                                updateView(idx);
-                                                        } else {
-                                                                updateView(idx);
-                                                        }
-                                                }
-                                        });
-
-                                        updateView();
-                                </script>
-			</body>
-			</html>
-		`;
-
-                panel.webview.html = hexViewHtml;
-
-               panel.webview.onDidReceiveMessage(message => {
-                       if (message.type === 'cursorMove') {
-                               statusBarItem.text = `Offset: 0x${message.index.toString(16).padStart(8, '0')}`;
-                       } else if (message.type === 'formatChange') {
-                               const selected = message.value as string;
-                               if (selected && formatPaths[selected]) {
-                                       try {
-                                               const content = fs.readFileSync(formatPaths[selected], 'utf8');
-                                               currentFormat = parseFormatFile(content);
-                                               if (!currentFormat.structs['Root']) {
-                                                       throw new Error('Format file lacks Root struct');
-                                               }
-                                               const tree = parseBinary(fileBytes, currentFormat);
-                                               const html = treeToHtml(tree);
-                                               panel.webview.postMessage({ type: 'treeData', html });
-                                       } catch (err: any) {
-                                               const msg = err?.message || String(err);
-                                               output.appendLine(`[parse] ${msg}`);
-                                               if (err?.stack) {
-                                                       output.appendLine(err.stack);
-                                               }
-                                               console.error('Parse failed', err);
-                                               vscode.window.showErrorMessage('Parse failed: ' + msg + '. See "binpp" output for details.');
-                                               panel.webview.postMessage({ type: 'treeData', html: '' });
-                                       }
-                               } else {
-                                       panel.webview.postMessage({ type: 'treeData', html: '' });
-                               }
-                       }
-               });
-
-               panel.onDidDispose(() => {
-                       statusBarItem.hide();
-               });
+        panel.webview.html = getHexViewHtml(panel.webview, context.extensionUri, {
+            base64Data,
+            formatOptions: formatOptionsHtml,
+            initialBytesPerLine: 16,
+            initialOffset: 0,
         });
 
-       context.subscriptions.push(disposable);
-       context.subscriptions.push(output);
+        panel.webview.onDidReceiveMessage(message => {
+            if (message.type === 'cursorMove') {
+                statusBarItem.text = `Offset: 0x${message.index.toString(16).padStart(8, '0')}`;
+            } else if (message.type === 'formatChange') {
+                const selected = message.value as string;
+                if (selected && formatPaths[selected]) {
+                    try {
+                        const content = fs.readFileSync(formatPaths[selected], 'utf8');
+                        currentFormat = parseFormatFile(content);
+                        if (!currentFormat.structs['Root']) {
+                            throw new Error('Format file lacks Root struct');
+                        }
+                        const tree = parseBinary(fileBytes, currentFormat);
+                        const html = treeToHtml(tree);
+                        panel.webview.postMessage({ type: 'treeData', html });
+                    } catch (err: any) {
+                        const msg = err?.message || String(err);
+                        output.appendLine(`[parse] ${msg}`);
+                        if (err?.stack) {
+                            output.appendLine(err.stack);
+                        }
+                        vscode.window.showErrorMessage('Parse failed: ' + msg + '. See "binpp" output for details.');
+                        panel.webview.postMessage({ type: 'treeData', html: '' });
+                    }
+                } else {
+                    panel.webview.postMessage({ type: 'treeData', html: '' });
+                }
+            }
+        });
+
+        panel.onDidDispose(() => {
+            statusBarItem.hide();
+        });
+    });
+
+    context.subscriptions.push(disposable);
+    context.subscriptions.push(output);
 }

--- a/src/parser/binary.ts
+++ b/src/parser/binary.ts
@@ -1,33 +1,4 @@
-export interface FieldDef {
-    name: string;
-    type: string;
-    lengthExpr?: string;
-}
-
-export interface StructDef {
-    name: string;
-    fields: FieldDef[];
-}
-
-export interface EnumDef {
-    name: string;
-    underlying: string;
-    entries: Record<number, string>;
-}
-
-export interface FormatDef {
-    structs: Record<string, StructDef>;
-    enums: Record<string, EnumDef>;
-}
-
-export interface TreeNode {
-    name: string;
-    type: string;
-    offset: number;
-    size: number;
-    value?: number | string | (number | string)[];
-    children?: TreeNode[];
-}
+import { FieldDef, StructDef, EnumDef, FormatDef, TreeNode } from './types';
 
 const builtinSizes: Record<string, number> = {
     char: 1,
@@ -38,54 +9,6 @@ const builtinSizes: Record<string, number> = {
     int32_t: 4,
     uint32_t: 4,
 };
-
-export function parseFormatFile(content: string): FormatDef {
-    const structs: Record<string, StructDef> = {};
-    const enums: Record<string, EnumDef> = {};
-
-    const enumRegex = /enum(?:\s+class)?\s+(\w+)(?:\s*:\s*(\w+))?\s*{([\s\S]*?)}\s*;/g;
-    let m: RegExpExecArray | null;
-    while ((m = enumRegex.exec(content)) !== null) {
-        const name = m[1];
-        const underlying = m[2] || 'int32_t';
-        const body = m[3];
-        const entries: Record<number, string> = {};
-        const itemRegex = /(\w+)(?:\s*=\s*([^,]+))?/g;
-        let i: RegExpExecArray | null;
-        let value = 0;
-        while ((i = itemRegex.exec(body)) !== null) {
-            const ename = i[1];
-            const valStr = i[2];
-            if (valStr) {
-                const parsed = parseInt(valStr.trim(), 0);
-                if (!isNaN(parsed)) {
-                    value = parsed;
-                }
-            }
-            entries[value] = ename;
-            value++;
-        }
-        enums[name] = { name, underlying, entries };
-    }
-
-    const structRegex = /struct\s+(\w+)\s*{([\s\S]*?)}\s*;/g;
-    while ((m = structRegex.exec(content)) !== null) {
-        const name = m[1];
-        const body = m[2];
-        const fields: FieldDef[] = [];
-        const lineRegex = /([a-zA-Z_]\w*)\s+([a-zA-Z_]\w*)(\s*\[(.+?)\])?\s*;/g;
-        let f: RegExpExecArray | null;
-        while ((f = lineRegex.exec(body)) !== null) {
-            const type = f[1];
-            const fname = f[2];
-            const lengthExpr = f[4];
-            fields.push({ name: fname, type, lengthExpr });
-        }
-        structs[name] = { name, fields };
-    }
-
-    return { structs, enums };
-}
 
 export function parseBinary(bytes: Uint8Array, format: FormatDef, rootName = 'Root'): TreeNode {
     const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
@@ -177,34 +100,4 @@ export function parseBinary(bytes: Uint8Array, format: FormatDef, rootName = 'Ro
     }
 
     return parseStruct(rootName, {});
-}
-
-let rowCounter = 0;
-
-function treeRows(node: TreeNode, depth = 0): string {
-    const indent = depth * 20;
-    const id = ++rowCounter;
-    const hasChildren = !!(node.children && node.children.length);
-    const value = hasChildren
-        ? ''
-        : node.value !== undefined
-            ? Array.isArray(node.value)
-                ? '[' + node.value.join(', ') + ']'
-                : String(node.value)
-            : '';
-    const arrow = hasChildren ? `<span class="toggle" data-id="${id}">▾</span>` : '';
-    let html = `<tr data-id="${id}" data-depth="${depth}" data-hide-count="0"><td class="name" style="padding-left:${indent}px">${arrow}${node.name}</td>` +
-        `<td>${value}</td><td>${node.type}</td></tr>`;
-    if (node.children) {
-        for (const c of node.children) {
-            html += treeRows(c, depth + 1);
-        }
-    }
-    return html;
-}
-
-export function treeToHtml(node: TreeNode): string {
-    rowCounter = 0;
-    const rows = treeRows(node);
-    return `<table class="tree-table"><thead><tr><th>Name</th><th>Value</th><th>Type</th></tr></thead><tbody>${rows}</tbody></table>`;
 }

--- a/src/parser/format.ts
+++ b/src/parser/format.ts
@@ -1,0 +1,49 @@
+import { FieldDef, StructDef, EnumDef, FormatDef } from './types';
+
+export function parseFormatFile(content: string): FormatDef {
+    const structs: Record<string, StructDef> = {};
+    const enums: Record<string, EnumDef> = {};
+
+    const enumRegex = /enum(?:\s+class)?\s+(\w+)(?:\s*:\s*(\w+))?\s*{([\s\S]*?)}\s*;/g;
+    let m: RegExpExecArray | null;
+    while ((m = enumRegex.exec(content)) !== null) {
+        const name = m[1];
+        const underlying = m[2] || 'int32_t';
+        const body = m[3];
+        const entries: Record<number, string> = {};
+        const itemRegex = /(\w+)(?:\s*=\s*([^,]+))?/g;
+        let i: RegExpExecArray | null;
+        let value = 0;
+        while ((i = itemRegex.exec(body)) !== null) {
+            const ename = i[1];
+            const valStr = i[2];
+            if (valStr) {
+                const parsed = parseInt(valStr.trim(), 0);
+                if (!isNaN(parsed)) {
+                    value = parsed;
+                }
+            }
+            entries[value] = ename;
+            value++;
+        }
+        enums[name] = { name, underlying, entries };
+    }
+
+    const structRegex = /struct\s+(\w+)\s*{([\s\S]*?)}\s*;/g;
+    while ((m = structRegex.exec(content)) !== null) {
+        const name = m[1];
+        const body = m[2];
+        const fields: FieldDef[] = [];
+        const lineRegex = /([a-zA-Z_]\w*)\s+([a-zA-Z_]\w*)(\s*\[(.+?)\])?\s*;/g;
+        let f: RegExpExecArray | null;
+        while ((f = lineRegex.exec(body)) !== null) {
+            const type = f[1];
+            const fname = f[2];
+            const lengthExpr = f[4];
+            fields.push({ name: fname, type, lengthExpr });
+        }
+        structs[name] = { name, fields };
+    }
+
+    return { structs, enums };
+}

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './format';
+export * from './binary';
+export * from './tree';

--- a/src/parser/tree.ts
+++ b/src/parser/tree.ts
@@ -1,0 +1,31 @@
+import { TreeNode } from './types';
+
+let rowCounter = 0;
+
+function treeRows(node: TreeNode, depth = 0): string {
+    const indent = depth * 20;
+    const id = ++rowCounter;
+    const hasChildren = !!(node.children && node.children.length);
+    const value = hasChildren
+        ? ''
+        : node.value !== undefined
+            ? Array.isArray(node.value)
+                ? '[' + node.value.join(', ') + ']'
+                : String(node.value)
+            : '';
+    const arrow = hasChildren ? `<span class="toggle" data-id="${id}">▾</span>` : '';
+    let html = `<tr data-id="${id}" data-depth="${depth}" data-hide-count="0"><td class="name" style="padding-left:${indent}px">${arrow}${node.name}</td>` +
+        `<td>${value}</td><td>${node.type}</td></tr>`;
+    if (node.children) {
+        for (const c of node.children) {
+            html += treeRows(c, depth + 1);
+        }
+    }
+    return html;
+}
+
+export function treeToHtml(node: TreeNode): string {
+    rowCounter = 0;
+    const rows = treeRows(node);
+    return `<table class="tree-table"><thead><tr><th>Name</th><th>Value</th><th>Type</th></tr></thead><tbody>${rows}</tbody></table>`;
+}

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1,0 +1,30 @@
+export interface FieldDef {
+    name: string;
+    type: string;
+    lengthExpr?: string;
+}
+
+export interface StructDef {
+    name: string;
+    fields: FieldDef[];
+}
+
+export interface EnumDef {
+    name: string;
+    underlying: string;
+    entries: Record<number, string>;
+}
+
+export interface FormatDef {
+    structs: Record<string, StructDef>;
+    enums: Record<string, EnumDef>;
+}
+
+export interface TreeNode {
+    name: string;
+    type: string;
+    offset: number;
+    size: number;
+    value?: number | string | (number | string)[];
+    children?: TreeNode[];
+}

--- a/src/webview/html.ts
+++ b/src/webview/html.ts
@@ -1,0 +1,76 @@
+import * as vscode from 'vscode';
+
+export interface WebviewOptions {
+    base64Data: string;
+    formatOptions: string;
+    initialBytesPerLine: number;
+    initialOffset: number;
+}
+
+export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri, opts: WebviewOptions): string {
+    const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'out', 'webview', 'script.js'));
+    return `
+<html>
+<head>
+    <meta name="color-scheme" content="light dark" />
+    <style>
+        body {
+            font-family: monospace;
+            display: flex;
+            flex-direction: column;
+            color: var(--vscode-editor-foreground);
+            background-color: var(--vscode-editor-background);
+        }
+        .toolbar {
+            margin-bottom: 10px;
+            position: sticky;
+            top: 0;
+            background-color: var(--vscode-editor-background);
+            color: var(--vscode-editor-foreground);
+            padding: 4px;
+            z-index: 1;
+        }
+        input, select {
+            background-color: var(--vscode-input-background);
+            color: var(--vscode-input-foreground);
+            border: 1px solid var(--vscode-input-border);
+        }
+        table { border-collapse: collapse; margin-right: 10px; }
+        td { padding: 0 5px; vertical-align: top; }
+        .address td { color: gray; user-select: text; }
+        .hex td { letter-spacing: 0.1em; user-select: text; }
+        .ascii td { padding-left: 10px; user-select: text; }
+        .byte { outline: none; min-width: 20px; text-align: center; }
+        .view-container { display: flex; }
+        .tree-table { border-collapse: collapse; width: 100%; }
+        .tree-table td, .tree-table th { border: 1px solid; padding: 2px 4px; }
+        .tree-table .name { white-space: pre; }
+        .tree-table .toggle { cursor: pointer; display: inline-block; width: 1em; }
+        .tree-table tr.hidden { display: none; }
+    </style>
+</head>
+<body data-base64="${opts.base64Data}" data-bytes-per-line="${opts.initialBytesPerLine}" data-offset="${opts.initialOffset}">
+<div class="toolbar">
+    <label for="offset">Offset: </label>
+    <input id="offset" type="number" value="0" style="width:100px;" />
+    <label for="bytesPerLine">Bytes per line: </label>
+    <select id="bytesPerLine">
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="4">4</option>
+        <option value="8">8</option>
+        <option value="16" selected>16</option>
+        <option value="32">32</option>
+        <option value="64">64</option>
+        <option value="128">128</option>
+    </select>
+    <label for="formatSelect">Format: </label>
+    <select id="formatSelect">
+        ${opts.formatOptions}
+    </select>
+</div>
+<div class="view-container" id="viewContainer"></div>
+<script src="${scriptUri}"></script>
+</body>
+</html>`;
+}

--- a/src/webview/script.ts
+++ b/src/webview/script.ts
@@ -1,0 +1,95 @@
+declare const acquireVsCodeApi: any;
+
+const vscode = acquireVsCodeApi();
+const rawData = document.body.dataset.base64 || '';
+const bytes = Uint8Array.from(atob(rawData), c => c.charCodeAt(0));
+
+const select = document.getElementById('bytesPerLine') as HTMLSelectElement;
+const formatSelect = document.getElementById('formatSelect') as HTMLSelectElement | null;
+const offsetInput = document.getElementById('offset') as HTMLInputElement;
+const viewContainer = document.getElementById('viewContainer') as HTMLElement;
+
+let currentFocusIndex = -1;
+let currentBytesPerLine = parseInt(document.body.dataset.bytesPerLine || '16', 10);
+let currentOffset = parseInt(document.body.dataset.offset || '0', 10);
+
+function renderView(bytesPerLine: number, offset: number): string {
+    const slice = bytes.slice(offset);
+    let addr = '';
+    let hex = '';
+    let ascii = '';
+    for (let i = 0; i < slice.length; i += bytesPerLine) {
+        const row = slice.slice(i, i + bytesPerLine);
+        const address = (offset + i).toString(16).padStart(8, '0');
+        addr += '<tr><td>' + address + '</td></tr>';
+        hex += '<tr>';
+        ascii += '<tr>';
+        for (let j = 0; j < row.length; j++) {
+            const idx = offset + i + j;
+            const b = row[j];
+            hex += `<td class="byte" data-index="${idx}" contenteditable="true">${b.toString(16).padStart(2, '0')}</td>`;
+            ascii += `<td>${(b >= 32 && b <= 126) ? String.fromCharCode(b) : '.'}</td>`;
+        }
+        hex += '</tr>';
+        ascii += '</tr>';
+    }
+    return '<table class="address">' + addr + '</table>' +
+           '<table class="hex">' + hex + '</table>' +
+           '<table class="ascii">' + ascii + '</table>';
+}
+
+function updateView(focusIndex = -1): void {
+    currentBytesPerLine = parseInt(select.value, 10);
+    currentOffset = parseInt(offsetInput.value, 10) || 0;
+    viewContainer.style.display = 'flex';
+    viewContainer.innerHTML = renderView(currentBytesPerLine, currentOffset);
+    if (focusIndex >= 0) {
+        const el = viewContainer.querySelector(`td.byte[data-index="${focusIndex}"]`);
+        if (el instanceof HTMLElement) {
+            el.focus();
+        }
+    }
+}
+
+select.addEventListener('change', () => updateView());
+offsetInput.addEventListener('change', () => updateView());
+formatSelect?.addEventListener('change', () => {
+    vscode.postMessage({ type: 'formatChange', value: formatSelect.value });
+});
+
+window.addEventListener('message', event => {
+    const msg = event.data;
+    if (msg.type === 'treeData') {
+        if (msg.html) {
+            viewContainer.style.display = 'block';
+            viewContainer.innerHTML = msg.html;
+        } else {
+            updateView();
+        }
+    }
+});
+
+viewContainer.addEventListener('focusin', e => {
+    const target = e.target as HTMLElement;
+    if (target && target.classList.contains('byte')) {
+        currentFocusIndex = parseInt(target.getAttribute('data-index') || '0', 10);
+        vscode.postMessage({ type: 'cursorMove', index: currentFocusIndex });
+    }
+});
+
+viewContainer.addEventListener('input', e => {
+    const target = e.target as HTMLElement;
+    if (target && target.classList.contains('byte')) {
+        const idx = parseInt(target.getAttribute('data-index') || '0', 10);
+        const text = (target.textContent || '').trim();
+        if (/^[0-9a-fA-F]{1,2}$/.test(text)) {
+            const value = parseInt(text, 16);
+            bytes[idx] = value;
+            updateView(idx);
+        } else {
+            updateView(idx);
+        }
+    }
+});
+
+updateView();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"module": "commonjs",
 		"target": "es2020",
-		"lib": ["es2020"],
+                "lib": ["es2020", "dom"],
 		"outDir": "out",
 		"sourceMap": true,
 		"strict": true,


### PR DESCRIPTION
## Summary
- modularize parser into format, binary parser, and HTML tree
- load `binpp.json` with a new config helper
- move webview HTML generation and scripting into dedicated modules
- trim extension activation logic
- support DOM library in `tsconfig.json`

## Testing
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_684f04a063e083249fc938a55a44977b