### PR TITLE
Add reload button

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ export function activate(context: vscode.ExtensionContext): void {
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         const { html: formatOptionsHtml, paths: formatPaths } = loadFormatOptions(workspaceFolder, output);
         let currentFormat: FormatDef | undefined;
+        let currentFormatPath: string | undefined;
 
         const panel = vscode.window.createWebviewPanel(
             'hexView',
@@ -29,8 +30,8 @@ export function activate(context: vscode.ExtensionContext): void {
             { enableScripts: true }
         );
 
-        const fileBytes = fs.readFileSync(document.uri.fsPath);
-        const base64Data = fileBytes.toString('base64');
+        let fileBytes = fs.readFileSync(document.uri.fsPath);
+        let base64Data = fileBytes.toString('base64');
 
         const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
         statusBarItem.text = 'Offset: 0x00000000';
@@ -51,7 +52,8 @@ export function activate(context: vscode.ExtensionContext): void {
                 const selected = message.value as string;
                 if (selected && formatPaths[selected]) {
                     try {
-                        const content = fs.readFileSync(formatPaths[selected], 'utf8');
+                        currentFormatPath = formatPaths[selected];
+                        const content = fs.readFileSync(currentFormatPath, 'utf8');
                         currentFormat = parseFormatFile(content);
                         if (!currentFormat.structs['Root']) {
                             throw new Error('Format file lacks Root struct');
@@ -69,7 +71,34 @@ export function activate(context: vscode.ExtensionContext): void {
                         panel.webview.postMessage({ type: 'treeData', html: '' });
                     }
                 } else {
+                    currentFormatPath = undefined;
+                    currentFormat = undefined;
                     panel.webview.postMessage({ type: 'treeData', html: '' });
+                }
+            } else if (message.type === 'reload') {
+                try {
+                    fileBytes = fs.readFileSync(document.uri.fsPath);
+                    base64Data = fileBytes.toString('base64');
+                    panel.webview.postMessage({ type: 'fileData', base64Data });
+                    if (currentFormatPath) {
+                        const content = fs.readFileSync(currentFormatPath, 'utf8');
+                        currentFormat = parseFormatFile(content);
+                        if (!currentFormat.structs['Root']) {
+                            throw new Error('Format file lacks Root struct');
+                        }
+                        const tree = parseBinary(fileBytes, currentFormat);
+                        const html = treeToHtml(tree);
+                        panel.webview.postMessage({ type: 'treeData', html });
+                    } else {
+                        panel.webview.postMessage({ type: 'treeData', html: '' });
+                    }
+                } catch (err: any) {
+                    const msg = err?.message || String(err);
+                    output.appendLine(`[reload] ${msg}`);
+                    if (err?.stack) {
+                        output.appendLine(err.stack);
+                    }
+                    vscode.window.showErrorMessage('Reload failed: ' + msg + '. See "binpp" output for details.');
                 }
             }
         });

--- a/src/webview/html.ts
+++ b/src/webview/html.ts
@@ -68,6 +68,7 @@ export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri
     <select id="formatSelect">
         ${opts.formatOptions}
     </select>
+    <button id="reload">Reload</button>
 </div>
 <div class="view-container" id="viewContainer"></div>
 <script src="${scriptUri}"></script>

--- a/src/webview/html.ts
+++ b/src/webview/html.ts
@@ -35,6 +35,15 @@ export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri
             color: var(--vscode-input-foreground);
             border: 1px solid var(--vscode-input-border);
         }
+        button {
+            background-color: var(--vscode-button-background);
+            color: var(--vscode-button-foreground);
+            border: 1px solid var(--vscode-button-border);
+            padding: 2px 8px;
+        }
+        button:hover {
+            background-color: var(--vscode-button-hoverBackground);
+        }
         table { border-collapse: collapse; margin-right: 10px; }
         td { padding: 0 5px; vertical-align: top; }
         .address td { color: gray; user-select: text; }

--- a/src/webview/script.ts
+++ b/src/webview/script.ts
@@ -2,11 +2,12 @@ declare const acquireVsCodeApi: any;
 
 const vscode = acquireVsCodeApi();
 const rawData = document.body.dataset.base64 || '';
-const bytes = Uint8Array.from(atob(rawData), c => c.charCodeAt(0));
+let bytes = Uint8Array.from(atob(rawData), c => c.charCodeAt(0));
 
 const select = document.getElementById('bytesPerLine') as HTMLSelectElement;
 const formatSelect = document.getElementById('formatSelect') as HTMLSelectElement | null;
 const offsetInput = document.getElementById('offset') as HTMLInputElement;
+const reloadButton = document.getElementById('reload') as HTMLButtonElement | null;
 const viewContainer = document.getElementById('viewContainer') as HTMLElement;
 
 let currentFocusIndex = -1;
@@ -56,6 +57,9 @@ offsetInput.addEventListener('change', () => updateView());
 formatSelect?.addEventListener('change', () => {
     vscode.postMessage({ type: 'formatChange', value: formatSelect.value });
 });
+reloadButton?.addEventListener('click', () => {
+    vscode.postMessage({ type: 'reload' });
+});
 
 window.addEventListener('message', event => {
     const msg = event.data;
@@ -66,6 +70,11 @@ window.addEventListener('message', event => {
         } else {
             updateView();
         }
+    } else if (msg.type === 'fileData') {
+        const base64 = msg.base64Data as string;
+        document.body.dataset.base64 = base64;
+        bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+        updateView(currentFocusIndex);
     }
 });
 


### PR DESCRIPTION
## Summary
- add reload button in the webview toolbar
- implement reload logic in script to request/receive refreshed data
- update extension message handling for reloads

## Testing
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_684f1b8f1cc88324b6da9eeb414a6d81