### PR TITLE
Implement array limit

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ export function activate(context: vscode.ExtensionContext): void {
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         const { html: formatOptionsHtml, paths: formatPaths } = loadFormatOptions(workspaceFolder, output);
         let currentFormat: FormatDef | undefined;
+        let currentArrayLimit = 10000;
 
         const panel = vscode.window.createWebviewPanel(
             'hexView',
@@ -42,13 +43,15 @@ export function activate(context: vscode.ExtensionContext): void {
             formatOptions: formatOptionsHtml,
             initialBytesPerLine: 16,
             initialOffset: 0,
+            initialArrayLimit: currentArrayLimit,
         });
 
         panel.webview.onDidReceiveMessage(message => {
             if (message.type === 'cursorMove') {
                 statusBarItem.text = `Offset: 0x${message.index.toString(16).padStart(8, '0')}`;
-            } else if (message.type === 'formatChange') {
-                const selected = message.value as string;
+            } else if (message.type === 'parse') {
+                const selected = message.format as string;
+                currentArrayLimit = typeof message.limit === 'number' ? message.limit : currentArrayLimit;
                 if (selected && formatPaths[selected]) {
                     try {
                         const content = fs.readFileSync(formatPaths[selected], 'utf8');
@@ -56,7 +59,7 @@ export function activate(context: vscode.ExtensionContext): void {
                         if (!currentFormat.structs['Root']) {
                             throw new Error('Format file lacks Root struct');
                         }
-                        const tree = parseBinary(fileBytes, currentFormat);
+                        const tree = parseBinary(fileBytes, currentFormat, currentArrayLimit);
                         const html = treeToHtml(tree);
                         panel.webview.postMessage({ type: 'treeData', html });
                     } catch (err: any) {

--- a/src/parser/binary.ts
+++ b/src/parser/binary.ts
@@ -10,7 +10,12 @@ const builtinSizes: Record<string, number> = {
     uint32_t: 4,
 };
 
-export function parseBinary(bytes: Uint8Array, format: FormatDef, rootName = 'Root'): TreeNode {
+export function parseBinary(
+    bytes: Uint8Array,
+    format: FormatDef,
+    maxArrayLength = 10000,
+    rootName = 'Root'
+): TreeNode {
     const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
     let offset = 0;
     const scopeStack: Record<string, any>[] = [];
@@ -48,6 +53,9 @@ export function parseBinary(bytes: Uint8Array, format: FormatDef, rootName = 'Ro
 
     function parseField(field: FieldDef, ctx: Record<string, any>): TreeNode {
         const count = field.lengthExpr ? Math.max(0, evaluate(field.lengthExpr, ctx)) : 1;
+        if (count > maxArrayLength) {
+            throw new Error(`Array '${field.name}' length ${count} exceeds limit ${maxArrayLength}`);
+        }
         const enumDef = format.enums[field.type];
         const baseType = enumDef?.underlying || field.type;
         if (format.structs[baseType]) {

--- a/src/webview/html.ts
+++ b/src/webview/html.ts
@@ -5,6 +5,7 @@ export interface WebviewOptions {
     formatOptions: string;
     initialBytesPerLine: number;
     initialOffset: number;
+    initialArrayLimit: number;
 }
 
 export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri, opts: WebviewOptions): string {
@@ -49,7 +50,7 @@ export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri
         .tree-table tr.hidden { display: none; }
     </style>
 </head>
-<body data-base64="${opts.base64Data}" data-bytes-per-line="${opts.initialBytesPerLine}" data-offset="${opts.initialOffset}">
+<body data-base64="${opts.base64Data}" data-bytes-per-line="${opts.initialBytesPerLine}" data-offset="${opts.initialOffset}" data-array-limit="${opts.initialArrayLimit}">
 <div class="toolbar">
     <label for="offset">Offset: </label>
     <input id="offset" type="number" value="0" style="width:100px;" />
@@ -68,6 +69,8 @@ export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri
     <select id="formatSelect">
         ${opts.formatOptions}
     </select>
+    <label for="arrayLimit">Array limit: </label>
+    <input id="arrayLimit" type="number" value="${opts.initialArrayLimit}" style="width:80px;" />
 </div>
 <div class="view-container" id="viewContainer"></div>
 <script src="${scriptUri}"></script>

--- a/src/webview/script.ts
+++ b/src/webview/script.ts
@@ -7,11 +7,13 @@ const bytes = Uint8Array.from(atob(rawData), c => c.charCodeAt(0));
 const select = document.getElementById('bytesPerLine') as HTMLSelectElement;
 const formatSelect = document.getElementById('formatSelect') as HTMLSelectElement | null;
 const offsetInput = document.getElementById('offset') as HTMLInputElement;
+const arrayLimitInput = document.getElementById('arrayLimit') as HTMLInputElement | null;
 const viewContainer = document.getElementById('viewContainer') as HTMLElement;
 
 let currentFocusIndex = -1;
 let currentBytesPerLine = parseInt(document.body.dataset.bytesPerLine || '16', 10);
 let currentOffset = parseInt(document.body.dataset.offset || '0', 10);
+let currentArrayLimit = parseInt(document.body.dataset.arrayLimit || '10000', 10);
 
 function renderView(bytesPerLine: number, offset: number): string {
     const slice = bytes.slice(offset);
@@ -53,9 +55,16 @@ function updateView(focusIndex = -1): void {
 
 select.addEventListener('change', () => updateView());
 offsetInput.addEventListener('change', () => updateView());
-formatSelect?.addEventListener('change', () => {
-    vscode.postMessage({ type: 'formatChange', value: formatSelect.value });
-});
+function sendParseRequest(): void {
+    if (!formatSelect) {
+        return;
+    }
+    currentArrayLimit = parseInt(arrayLimitInput?.value || '0', 10) || currentArrayLimit;
+    vscode.postMessage({ type: 'parse', format: formatSelect.value, limit: currentArrayLimit });
+}
+
+formatSelect?.addEventListener('change', sendParseRequest);
+arrayLimitInput?.addEventListener('change', sendParseRequest);
 
 window.addEventListener('message', event => {
     const msg = event.data;


### PR DESCRIPTION
## Summary
- allow controlling the maximum number of array elements parsed
- expose array limit option in the webview toolbar
- stop parsing and throw an error when an array exceeds the limit

## Testing
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_684f1be9c4a483249f6fbe4bed64d684