### PR TITLE
Auto select matching format

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,14 @@ export function activate(context: vscode.ExtensionContext): void {
 
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         const { html: formatOptionsHtml, paths: formatPaths } = loadFormatOptions(workspaceFolder, output);
+        let initialFormat: string | undefined;
+        const ext = path.extname(fileName).replace('.', '');
+        if (ext) {
+            const candidate = `${ext}.h`;
+            if (formatPaths[candidate]) {
+                initialFormat = candidate;
+            }
+        }
         let currentFormat: FormatDef | undefined;
         let currentArrayLimit = 10000;
         let currentFormatPath: string | undefined;
@@ -45,6 +53,7 @@ export function activate(context: vscode.ExtensionContext): void {
             initialBytesPerLine: 16,
             initialOffset: 0,
             initialArrayLimit: currentArrayLimit,
+            initialFormat,
         });
 
         panel.webview.onDidReceiveMessage(message => {

--- a/src/webview/html.ts
+++ b/src/webview/html.ts
@@ -6,6 +6,7 @@ export interface WebviewOptions {
     initialBytesPerLine: number;
     initialOffset: number;
     initialArrayLimit: number;
+    initialFormat?: string;
 }
 
 export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri, opts: WebviewOptions): string {
@@ -81,7 +82,7 @@ export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri
         <option value="128">128</option>
     </select>
     <label for="formatSelect">Format: </label>
-    <select id="formatSelect">
+    <select id="formatSelect" data-initial-format="${opts.initialFormat ?? ''}">
         ${opts.formatOptions}
     </select>
     <label for="arrayLimit">Array limit: </label>

--- a/src/webview/script.ts
+++ b/src/webview/script.ts
@@ -16,6 +16,7 @@ let currentFocusIndex = -1;
 let currentBytesPerLine = parseInt(document.body.dataset.bytesPerLine || '16', 10);
 let currentOffset = parseInt(document.body.dataset.offset || '0', 10);
 let currentArrayLimit = parseInt(document.body.dataset.arrayLimit || '10000', 10);
+const initialFormat = formatSelect?.dataset.initialFormat || '';
 
 function renderView(bytesPerLine: number, offset: number): string {
     const slice = bytes.slice(offset);
@@ -109,3 +110,12 @@ viewContainer.addEventListener('input', e => {
 });
 
 updateView();
+if (formatSelect && initialFormat) {
+    for (const option of Array.from(formatSelect.options)) {
+        if (option.value === initialFormat) {
+            formatSelect.value = initialFormat;
+            sendParseRequest();
+            break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- automatically select format file that matches the previewed file extension
- expose the initial format info to the webview
- select matching option and parse immediately in the webview

## Testing
- `npm run compile`
- `npm run lint` *(fails: unexpected any, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_684f216080f483249d55a488567cc2d3