### PR TITLE
Fix webview reload when switching tabs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,10 @@ export function activate(context: vscode.ExtensionContext): void {
             'hexView',
             `Preview ${fileName}`,
             vscode.ViewColumn.One,
-            { enableScripts: true }
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true,
+            }
         );
 
         let fileBytes = fs.readFileSync(document.uri.fsPath);


### PR DESCRIPTION
## Summary
- keep the binary viewer webview alive when switching tabs

## Testing
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_684f2693a6bc832497870399479d7756