### PR TITLE
Add endian switch

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ export function activate(context: vscode.ExtensionContext): void {
         let currentFormat: FormatDef | undefined;
         let currentArrayLimit = 10000;
         let currentFormatPath: string | undefined;
+        let currentLittleEndian = true;
 
         const panel = vscode.window.createWebviewPanel(
             'hexView',
@@ -54,6 +55,7 @@ export function activate(context: vscode.ExtensionContext): void {
             initialOffset: 0,
             initialArrayLimit: currentArrayLimit,
             initialFormat,
+            initialEndian: 'LE',
         });
 
         panel.webview.onDidReceiveMessage(message => {
@@ -62,6 +64,7 @@ export function activate(context: vscode.ExtensionContext): void {
             } else if (message.type === 'parse') {
                 const selected = message.format as string;
                 currentArrayLimit = typeof message.limit === 'number' ? message.limit : currentArrayLimit;
+                currentLittleEndian = message.littleEndian !== false;
                 if (selected && formatPaths[selected]) {
                     try {
                         currentFormatPath = formatPaths[selected];
@@ -70,7 +73,7 @@ export function activate(context: vscode.ExtensionContext): void {
                         if (!currentFormat.structs['Root']) {
                             throw new Error('Format file lacks Root struct');
                         }
-                        const tree = parseBinary(fileBytes, currentFormat, currentArrayLimit);
+                        const tree = parseBinary(fileBytes, currentFormat, currentArrayLimit, 'Root', currentLittleEndian);
                         const html = treeToHtml(tree);
                         panel.webview.postMessage({ type: 'treeData', html });
                     } catch (err: unknown) {
@@ -88,6 +91,7 @@ export function activate(context: vscode.ExtensionContext): void {
                     panel.webview.postMessage({ type: 'treeData', html: '' });
                 }
             } else if (message.type === 'reload') {
+                currentLittleEndian = message.littleEndian !== false;
                 try {
                     fileBytes = fs.readFileSync(document.uri.fsPath);
                     base64Data = fileBytes.toString('base64');
@@ -98,7 +102,7 @@ export function activate(context: vscode.ExtensionContext): void {
                         if (!currentFormat.structs['Root']) {
                             throw new Error('Format file lacks Root struct');
                         }
-                        const tree = parseBinary(fileBytes, currentFormat);
+                        const tree = parseBinary(fileBytes, currentFormat, currentArrayLimit, 'Root', currentLittleEndian);
                         const html = treeToHtml(tree);
                         panel.webview.postMessage({ type: 'treeData', html });
                     } else {

--- a/src/parser/binary.ts
+++ b/src/parser/binary.ts
@@ -14,7 +14,8 @@ export function parseBinary(
     bytes: Uint8Array,
     format: FormatDef,
     maxArrayLength = 10000,
-    rootName = 'Root'
+    rootName = 'Root',
+    littleEndian = true
 ): TreeNode {
     const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
     let offset = 0;
@@ -94,13 +95,13 @@ export function parseBinary(
                 case 'uint8_t':
                     val = view.getUint8(offset); break;
                 case 'int16_t':
-                    val = view.getInt16(offset, true); break;
+                    val = view.getInt16(offset, littleEndian); break;
                 case 'uint16_t':
-                    val = view.getUint16(offset, true); break;
+                    val = view.getUint16(offset, littleEndian); break;
                 case 'int32_t':
-                    val = view.getInt32(offset, true); break;
+                    val = view.getInt32(offset, littleEndian); break;
                 default:
-                    val = view.getUint32(offset, true); break;
+                    val = view.getUint32(offset, littleEndian); break;
             }
             offset += bsize;
             values.push(val);

--- a/src/webview/html.ts
+++ b/src/webview/html.ts
@@ -7,6 +7,7 @@ export interface WebviewOptions {
     initialOffset: number;
     initialArrayLimit: number;
     initialFormat?: string;
+    initialEndian: 'LE' | 'BE';
 }
 
 export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri, opts: WebviewOptions): string {
@@ -84,6 +85,11 @@ export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri
     <label for="formatSelect">Format: </label>
     <select id="formatSelect" data-initial-format="${opts.initialFormat ?? ''}">
         ${opts.formatOptions}
+    </select>
+    <label for="endian">Endian: </label>
+    <select id="endian" data-initial-endian="${opts.initialEndian}">
+        <option value="LE"${opts.initialEndian === 'LE' ? ' selected' : ''}>Little Endian</option>
+        <option value="BE"${opts.initialEndian === 'BE' ? ' selected' : ''}>Big Endian</option>
     </select>
     <label for="arrayLimit">Array limit: </label>
     <input id="arrayLimit" type="number" value="${opts.initialArrayLimit}" style="width:80px;" />

--- a/src/webview/script.ts
+++ b/src/webview/script.ts
@@ -12,6 +12,7 @@ const formatSelect = document.getElementById('formatSelect') as HTMLSelectElemen
 const offsetInput = document.getElementById('offset') as HTMLInputElement;
 const arrayLimitInput = document.getElementById('arrayLimit') as HTMLInputElement | null;
 const reloadButton = document.getElementById('reload') as HTMLButtonElement | null;
+const endianSelect = document.getElementById('endian') as HTMLSelectElement | null;
 
 const viewContainer = document.getElementById('viewContainer') as HTMLElement;
 
@@ -20,6 +21,7 @@ let currentBytesPerLine = parseInt(document.body.dataset.bytesPerLine || '16', 1
 let currentOffset = parseInt(document.body.dataset.offset || '0', 10);
 let currentArrayLimit = parseInt(document.body.dataset.arrayLimit || '10000', 10);
 const initialFormat = formatSelect?.dataset.initialFormat || '';
+const initialEndian = endianSelect?.dataset.initialEndian || 'LE';
 
 function renderView(bytesPerLine: number, offset: number): string {
     const slice = bytes.slice(offset);
@@ -66,11 +68,17 @@ function sendParseRequest(): void {
         return;
     }
     currentArrayLimit = parseInt(arrayLimitInput?.value || '0', 10) || currentArrayLimit;
-    vscode.postMessage({ type: 'parse', format: formatSelect.value, limit: currentArrayLimit });
+    const little = (endianSelect?.value || 'LE') === 'LE';
+    vscode.postMessage({ type: 'parse', format: formatSelect.value, limit: currentArrayLimit, littleEndian: little });
 }
 
 formatSelect?.addEventListener('change', sendParseRequest);
 arrayLimitInput?.addEventListener('change', sendParseRequest);
+endianSelect?.addEventListener('change', sendParseRequest);
+reloadButton?.addEventListener('click', () => {
+    const little = (endianSelect?.value || 'LE') === 'LE';
+    vscode.postMessage({ type: 'reload', littleEndian: little });
+});
 
 window.addEventListener('message', event => {
     const msg = event.data;
@@ -121,4 +129,7 @@ if (formatSelect && initialFormat) {
             break;
         }
     }
+}
+if (endianSelect && initialEndian) {
+    endianSelect.value = initialEndian;
 }


### PR DESCRIPTION
## Summary
- add endian selection control in webview toolbar
- wire endian state through extension message handling
- parse binary data using chosen endianness

## Testing
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_684f26cd26488324a90f1d30bbdaf395