### PR TITLE
Add split HEX/struct view

### DIFF
--- a/src/parser/tree.ts
+++ b/src/parser/tree.ts
@@ -15,7 +15,7 @@ function treeRows(node: TreeNode, depth = 0): string {
             : '';
     const arrow = hasChildren ? `<span class="toggle" data-id="${id}">▾</span>` : '';
     const addr = `0x${node.offset.toString(16).padStart(8, '0')}`;
-    let html = `<tr data-id="${id}" data-depth="${depth}" data-hide-count="0"><td class="name" style="padding-left:${indent}px">${arrow}${node.name}</td>` +
+    let html = `<tr data-id="${id}" data-depth="${depth}" data-hide-count="0" data-offset="${node.offset}" data-size="${node.size}" data-type="${node.type}"><td class="name" style="padding-left:${indent}px">${arrow}${node.name}</td>` +
         `<td>${value}</td><td>${node.type}</td><td>${addr}</td></tr>`;
     if (node.children) {
         for (const c of node.children) {

--- a/src/webview/html.ts
+++ b/src/webview/html.ts
@@ -62,6 +62,9 @@ export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri
         #hexContainer, #treeContainer {
             overflow: auto;
         }
+        #hexContainer {
+            display: flex;
+        }
         #treeContainer { display: none; }
         #divider {
             height: 4px;

--- a/src/webview/html.ts
+++ b/src/webview/html.ts
@@ -53,7 +53,22 @@ export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri
         .hex td { letter-spacing: 0.1em; user-select: text; }
         .ascii td { padding-left: 10px; user-select: text; }
         .byte { outline: none; min-width: 20px; text-align: center; }
-        .view-container { display: flex; }
+        .view-container {
+            display: flex;
+            flex-direction: column;
+            flex: 1 1 auto;
+            height: 100%;
+        }
+        #hexContainer, #treeContainer {
+            overflow: auto;
+        }
+        #treeContainer { display: none; }
+        #divider {
+            height: 4px;
+            background: var(--vscode-editorGroup-border, gray);
+            cursor: row-resize;
+            display: none;
+        }
         .tree-table { border-collapse: collapse; width: 100%; }
         .tree-table td, .tree-table th { border: none; padding: 2px 4px; }
         .tree-table tbody tr:nth-child(odd) {
@@ -95,7 +110,11 @@ export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri
     <input id="arrayLimit" type="number" value="${opts.initialArrayLimit}" style="width:80px;" />
     <button id="reload">Reload</button>
 </div>
-<div class="view-container" id="viewContainer"></div>
+<div class="view-container" id="viewContainer">
+    <div id="hexContainer"></div>
+    <div id="divider"></div>
+    <div id="treeContainer"></div>
+</div>
 <script src="${scriptUri}"></script>
 </body>
 </html>`;

--- a/src/webview/html.ts
+++ b/src/webview/html.ts
@@ -17,12 +17,17 @@ export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri
 <head>
     <meta name="color-scheme" content="light dark" />
     <style>
+        html, body {
+            height: 100%;
+        }
         body {
             font-family: monospace;
             display: flex;
             flex-direction: column;
             color: var(--vscode-editor-foreground);
             background-color: var(--vscode-editor-background);
+            margin: 0;
+            overflow: hidden;
         }
         .toolbar {
             margin-bottom: 10px;
@@ -61,6 +66,7 @@ export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri
             flex-direction: column;
             flex: 1 1 auto;
             height: 100%;
+            overflow: hidden;
         }
         #hexContainer, #treeContainer {
             overflow: auto;

--- a/src/webview/html.ts
+++ b/src/webview/html.ts
@@ -53,6 +53,9 @@ export function getHexViewHtml(webview: vscode.Webview, extensionUri: vscode.Uri
         .hex td { letter-spacing: 0.1em; user-select: text; }
         .ascii td { padding-left: 10px; user-select: text; }
         .byte { outline: none; min-width: 20px; text-align: center; }
+        .byte.highlight {
+            background-color: var(--vscode-editor-selectionBackground, rgba(100,100,255,0.4));
+        }
         .view-container {
             display: flex;
             flex-direction: column;

--- a/src/webview/script.ts
+++ b/src/webview/script.ts
@@ -15,6 +15,11 @@ const reloadButton = document.getElementById('reload') as HTMLButtonElement | nu
 const endianSelect = document.getElementById('endian') as HTMLSelectElement | null;
 
 const viewContainer = document.getElementById('viewContainer') as HTMLElement;
+const hexContainer = document.getElementById('hexContainer') as HTMLElement;
+const treeContainer = document.getElementById('treeContainer') as HTMLElement;
+const divider = document.getElementById('divider') as HTMLElement;
+
+let isDragging = false;
 
 let currentFocusIndex = -1;
 let currentBytesPerLine = parseInt(document.body.dataset.bytesPerLine || '16', 10);
@@ -51,10 +56,9 @@ function renderView(bytesPerLine: number, offset: number): string {
 function updateView(focusIndex = -1): void {
     currentBytesPerLine = parseInt(select.value, 10);
     currentOffset = parseInt(offsetInput.value, 10) || 0;
-    viewContainer.style.display = 'flex';
-    viewContainer.innerHTML = renderView(currentBytesPerLine, currentOffset);
+    hexContainer.innerHTML = renderView(currentBytesPerLine, currentOffset);
     if (focusIndex >= 0) {
-        const el = viewContainer.querySelector(`td.byte[data-index="${focusIndex}"]`);
+        const el = hexContainer.querySelector(`td.byte[data-index="${focusIndex}"]`);
         if (el instanceof HTMLElement) {
             el.focus();
         }
@@ -80,14 +84,40 @@ reloadButton?.addEventListener('click', () => {
     vscode.postMessage({ type: 'reload', littleEndian: little });
 });
 
+divider.addEventListener('mousedown', e => {
+    isDragging = true;
+    e.preventDefault();
+});
+
+window.addEventListener('mousemove', e => {
+    if (!isDragging) {
+        return;
+    }
+    const rect = viewContainer.getBoundingClientRect();
+    const offset = e.clientY - rect.top;
+    const percent = Math.min(Math.max(offset / rect.height, 0.1), 0.9);
+    hexContainer.style.height = `${percent * 100}%`;
+    treeContainer.style.height = `${(1 - percent) * 100}%`;
+});
+
+window.addEventListener('mouseup', () => {
+    isDragging = false;
+});
+
 window.addEventListener('message', event => {
     const msg = event.data;
     if (msg.type === 'treeData') {
         if (msg.html) {
-            viewContainer.style.display = 'block';
-            viewContainer.innerHTML = msg.html;
+            treeContainer.style.display = 'block';
+            divider.style.display = 'block';
+            hexContainer.style.height = '60%';
+            treeContainer.style.height = '40%';
+            treeContainer.innerHTML = msg.html;
         } else {
-            updateView();
+            treeContainer.style.display = 'none';
+            divider.style.display = 'none';
+            hexContainer.style.height = '100%';
+            updateView(currentFocusIndex);
         }
     } else if (msg.type === 'fileData') {
         const base64 = msg.base64Data as string;
@@ -97,7 +127,7 @@ window.addEventListener('message', event => {
     }
 });
 
-viewContainer.addEventListener('focusin', e => {
+hexContainer.addEventListener('focusin', e => {
     const target = e.target as HTMLElement;
     if (target && target.classList.contains('byte')) {
         currentFocusIndex = parseInt(target.getAttribute('data-index') || '0', 10);
@@ -105,7 +135,7 @@ viewContainer.addEventListener('focusin', e => {
     }
 });
 
-viewContainer.addEventListener('input', e => {
+hexContainer.addEventListener('input', e => {
     const target = e.target as HTMLElement;
     if (target && target.classList.contains('byte')) {
         const idx = parseInt(target.getAttribute('data-index') || '0', 10);

--- a/src/webview/script.ts
+++ b/src/webview/script.ts
@@ -20,6 +20,8 @@ const treeContainer = document.getElementById('treeContainer') as HTMLElement;
 const divider = document.getElementById('divider') as HTMLElement;
 
 let isDragging = false;
+let highlightStart = -1;
+let highlightEnd = -1;
 
 let currentFocusIndex = -1;
 let currentBytesPerLine = parseInt(document.body.dataset.bytesPerLine || '16', 10);
@@ -53,10 +55,50 @@ function renderView(bytesPerLine: number, offset: number): string {
            '<table class="ascii">' + ascii + '</table>';
 }
 
+function clearHighlight(): void {
+    if (highlightStart >= 0 && highlightEnd >= 0) {
+        for (let i = highlightStart; i < highlightEnd; i++) {
+            const el = hexContainer.querySelector(`td.byte[data-index="${i}"]`);
+            if (el) {
+                el.classList.remove('highlight');
+            }
+        }
+    }
+    highlightStart = highlightEnd = -1;
+}
+
+function highlightRange(start: number, size: number): void {
+    clearHighlight();
+    highlightStart = start;
+    highlightEnd = start + size;
+    for (let i = highlightStart; i < highlightEnd; i++) {
+        const el = hexContainer.querySelector(`td.byte[data-index="${i}"]`);
+        if (el) {
+            el.classList.add('highlight');
+        }
+    }
+    const first = hexContainer.querySelector(`td.byte[data-index="${start}"]`);
+    if (first instanceof HTMLElement) {
+        first.scrollIntoView({ block: 'nearest' });
+    }
+}
+
 function updateView(focusIndex = -1): void {
     currentBytesPerLine = parseInt(select.value, 10);
     currentOffset = parseInt(offsetInput.value, 10) || 0;
     hexContainer.innerHTML = renderView(currentBytesPerLine, currentOffset);
+    if (highlightStart >= 0 && highlightEnd > highlightStart) {
+        for (let i = highlightStart; i < highlightEnd; i++) {
+            const el = hexContainer.querySelector(`td.byte[data-index="${i}"]`);
+            if (el) {
+                el.classList.add('highlight');
+            }
+        }
+        const first = hexContainer.querySelector(`td.byte[data-index="${highlightStart}"]`);
+        if (first instanceof HTMLElement) {
+            first.scrollIntoView({ block: 'nearest' });
+        }
+    }
     if (focusIndex >= 0) {
         const el = hexContainer.querySelector(`td.byte[data-index="${focusIndex}"]`);
         if (el instanceof HTMLElement) {
@@ -108,12 +150,14 @@ window.addEventListener('message', event => {
     const msg = event.data;
     if (msg.type === 'treeData') {
         if (msg.html) {
+            clearHighlight();
             treeContainer.style.display = 'block';
             divider.style.display = 'block';
             hexContainer.style.height = '60%';
             treeContainer.style.height = '40%';
             treeContainer.innerHTML = msg.html;
         } else {
+            clearHighlight();
             treeContainer.style.display = 'none';
             divider.style.display = 'none';
             hexContainer.style.height = '100%';
@@ -123,7 +167,27 @@ window.addEventListener('message', event => {
         const base64 = msg.base64Data as string;
         document.body.dataset.base64 = base64;
         bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+        clearHighlight();
         updateView(currentFocusIndex);
+    }
+});
+
+treeContainer.addEventListener('click', e => {
+    let target = e.target as HTMLElement | null;
+    while (target && target.tagName !== 'TR') {
+        target = target.parentElement;
+    }
+    if (!target) {
+        return;
+    }
+    const type = target.dataset.type || '';
+    if (type === 'struct') {
+        return;
+    }
+    const start = parseInt(target.dataset.offset || '0', 10);
+    const size = parseInt(target.dataset.size || '0', 10);
+    if (size > 0) {
+        highlightRange(start, size);
     }
 });
 


### PR DESCRIPTION
## Summary
- allow simultaneous HEX and struct view
- add resizable splitter between views

## Testing
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_6850f3c2bc44832490bb6fe9ba171cd4