### PR TITLE
Fix struct field display

### DIFF
--- a/src/parser/binary.ts
+++ b/src/parser/binary.ts
@@ -64,18 +64,27 @@ export function parseBinary(
         const enumDef = format.enums[field.type];
         const baseType = enumDef?.underlying || field.type;
         if (format.structs[baseType]) {
+            const start = offset;
+            if (count === 1) {
+                const childCtx: Record<string, unknown> = {};
+                const child = parseStruct(baseType, childCtx);
+                child.name = field.name;
+                child.type = field.type;
+                ctx[field.name] = childCtx;
+                return child;
+            }
             const children: TreeNode[] = [];
             const ctxValues: Record<string, unknown>[] = [];
-            const start = offset;
             for (let i = 0; i < count; i++) {
                 const childCtx: Record<string, unknown> = {};
                 const child = parseStruct(baseType, childCtx);
                 child.name = `${field.name}[${i}]`;
+                child.type = field.type;
                 children.push(child);
                 ctxValues.push(childCtx);
             }
             const size = offset - start;
-            ctx[field.name] = ctxValues.length === 1 ? ctxValues[0] : ctxValues;
+            ctx[field.name] = ctxValues;
             return { name: field.name, type: field.type, offset: start, size, children };
         }
 


### PR DESCRIPTION
## Summary
- prevent single struct members from appearing as 1-element arrays
- revert unintended change to the build map file

## Testing
- `npm run compile`
- `npm run lint` *(fails: Unexpected any in extension.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6850fdab8ab88324b9ca3345420bc254